### PR TITLE
Ruby 2.4/2.5 key_size fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ option         | default
 `:salt`        | `'encrypted cookie'`
 `:signed_salt` | `'signed encrypted cookie'`
 `:iterations`  | `1024`
-`:key_size`    | `64`
+`:key_size`    | `32`
 `:cipher`      | `'AES-256-CBC'`
 
 A list of supported algorithms can be obtained by

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
+
 require 'rubocop/rake_task'
 require 'rake/testtask'
 require 'rake/packagetask'
 require 'rubygems/package_task'
 
 desc 'Run linter and tests'
-task default: %i(rubocop test)
+task default: %i[rubocop test]
 
 RuboCop::RakeTask.new
 
@@ -14,11 +15,10 @@ Rake::TestTask.new do |t|
   # t.verbose = true
 end
 
-spec_path = File.expand_path('../rack_encrypted_cookie.gemspec', __FILE__)
+spec_path = File.expand_path('rack_encrypted_cookie.gemspec', __dir__)
 spec = Gem::Specification.load(spec_path)
 package_task = Gem::PackageTask.new(spec)
 package_task.define
-
 
 desc 'Release to rubygems.org'
 task release: :package do

--- a/lib/rack/session/encrypted_cookie.rb
+++ b/lib/rack/session/encrypted_cookie.rb
@@ -12,7 +12,7 @@ module Rack
         @secret_key_bases = options.values_at(:secret, :old_secret).compact
         return super if @secret_key_bases.empty?
         @iterations = options.fetch(:iterations, 1024)
-        @key_size = options.fetch(:key_size, 64)
+        @key_size = options.fetch(:key_size, 32)
         cipher = options.fetch(:cipher, 'AES-256-CBC')
         digest = options.fetch(:digest, 'SHA1')
         salt = options.fetch(:salt, 'encrypted cookie')

--- a/rack_encrypted_cookie.gemspec
+++ b/rack_encrypted_cookie.gemspec
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name = 'rack_encrypted_cookie'
   s.version = '1.0.0'
@@ -10,9 +11,9 @@ Gem::Specification.new do |s|
   s.files = ['lib/rack/session/encrypted_cookie.rb']
   s.homepage = 'https://github.com/tonytonyjan/rack_encrypted_cookie'
   s.required_ruby_version = '>= 2.3.0'
-  s.add_runtime_dependency 'rack'
   s.add_runtime_dependency 'coder_decorator', '>= 1.0.2'
+  s.add_runtime_dependency 'rack'
   s.add_development_dependency 'minitest'
-  s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'rubocop'
 end

--- a/test/spec_encrypted_cookie.rb
+++ b/test/spec_encrypted_cookie.rb
@@ -443,8 +443,9 @@ describe Rack::Session::EncryptedCookie do
       end
 
       def decode(str)
-        # rubocop:disable Lint/Eval
+        # rubocop:disable Security/Eval
         eval(str) if str
+        # rubocop:enable Security/Eval
       end
     end.new
     app_args = [app, { secret: 'test', coder: unsafe_coder }]


### PR DESCRIPTION
The Ruby 2.4 and 2.5 OpenSSL library requires the key to be _exactly_ 32 bytes for the chosen default cipher (this was previously silently truncated on Ruby 2.3, but is an error in 2.4 and later).

This PR changes the default so it does not need to be overridden to work under newer versions of the Ruby OpenSSL library.

( Ref. https://github.com/ruby/openssl/issues/116 )